### PR TITLE
Fixes for latest Ubuntu image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 FROM       ubuntu:latest
 
-RUN locale-gen en_US.UTF-8
+# Fixing debconf warning about TREM
+ENV        DEBIAN_FRONTEND teletype
+
+# Latest Ubuntu doesn't have pre-installed locales package (locale-gen) and 'ip' from iproute
+# apt-utils also fix warnings from debconfig
+RUN        apt-get clean && apt-get update && apt-get install -y --no-install-recommends apt-utils locales iproute
+RUN        locale-gen en_US.UTF-8
 
 # Decompress the tarball in the container
 ADD        qdb-*-linux-64bit-server.tar.gz /usr/
@@ -19,3 +25,4 @@ ENTRYPOINT ["/usr/bin/qdbd-docker-wrapper.sh"]
 
 # Expose the port qdbd is listening at
 EXPOSE     2836
+

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ This repository contains the **Dockerfile** of [QuasarDB](http://www.quasardb.ne
 
     docker run -d -p 2836:2836 --name qdb-server bureau14/qdb
 
+#### Run `qdbd` without [cluster keys](http://doc.quasardb.net/2.1.0/reference/qdb_cluster_keygen.html)
+
+    docker run -d -p 2836:2836 --name qdb-server bureau14/qdb --security=0
+
 #### Run `qdbd` w/ persistent directory
 
     docker run -d -p 2836:2836 -v <db-dir>:/var/lib/qdb --name qdb-server bureau14/qdb


### PR DESCRIPTION
Latest ubuntu doesn't have `local-gen` pre-installed as well as `ip` command.
This PR fixes it.
`DEBIAN_FRONTEND` and `apt-utils` suppress warnings due to ubuntu packet manager issues.